### PR TITLE
21 - Catch Get error on start

### DIFF
--- a/frontend/lib/services/api_service.dart
+++ b/frontend/lib/services/api_service.dart
@@ -92,7 +92,7 @@ class APIService {
   }
 
   Future<int> testFetch(String authToken) async {
-    Uri uri = Uri.http(_baseUrl, '/api/apps');
+    Uri uri = Uri.http(_baseUrl, '/api/dashboard');
     Map<String, String> headers = {
       HttpHeaders.contentTypeHeader: 'application/json',
     };
@@ -117,7 +117,6 @@ class APIService {
       uri,
       options: Options(headers: headers),
     );
-    print(response.data);
     if (response.statusCode == 200) {
       try {
         Dashboard dash;
@@ -131,6 +130,40 @@ class APIService {
       print(response.statusCode);
       print('Failed to retrive dashboard config');
     }
+  }
+
+  Future<bool> preRunCheck() async {
+    bool returnVal = false;
+    Uri uri = Uri.http(_baseUrl, '/api/dashboard');
+
+    Map<String, String> headers = {
+      HttpHeaders.contentTypeHeader: 'application/json',
+    };
+
+    _handleDioResponse(dynamic response) {
+      if (response.statusCode == 200) {
+        if (response.data.toString().contains("<!DOCTYPE html>")) {
+          returnVal = false;
+        } else {
+          returnVal = true;
+        }
+      } else {
+        returnVal = false;
+      }
+    }
+
+    _handleDioError(dynamic error) {
+      returnVal = false;
+    }
+
+    await Dio()
+        .getUri(
+          uri,
+          options: Options(headers: headers),
+        )
+        .then(_handleDioResponse)
+        .catchError(_handleDioError);
+    return returnVal;
   }
 
   Future<GeneratePasswordResponse> genPassword(String password) async {

--- a/frontend/lib/services/auth_service.dart
+++ b/frontend/lib/services/auth_service.dart
@@ -73,7 +73,7 @@ class AuthService {
 
   Stream<int> checkUserStream() async* {
     while (true) {
-      await Future.delayed(Duration(seconds: 2));
+      await Future.delayed(Duration(seconds: 5));
       if (_currentUser != null) {
         int respCode = await APIService.instance.testFetch(_currentUser.token);
         yield respCode;

--- a/frontend/lib/views/base_page_view.dart
+++ b/frontend/lib/views/base_page_view.dart
@@ -1,3 +1,4 @@
+import 'package:auto_size_text/auto_size_text.dart';
 import 'package:dashi/app/theme_data.dart';
 import 'package:dashi/views/settings_view.dart';
 import 'package:flutter/material.dart';
@@ -12,6 +13,90 @@ class BasePageView extends StatefulWidget {
 }
 
 PageController pageCont = PageController(initialPage: 0);
+
+_heading(String text) {
+  return Padding(
+    padding: const EdgeInsets.all(8.0),
+    child: FittedBox(
+      fit: BoxFit.fitWidth,
+      child: Text(
+        text,
+        style: TextStyle(fontSize: 25, fontWeight: FontWeight.bold),
+      ),
+    ),
+  );
+}
+
+_subHeading(String text) {
+  return FittedBox(
+    fit: BoxFit.fitWidth,
+    child: AutoSizeText(
+      text,
+      minFontSize: 9,
+      style: TextStyle(fontSize: 20, fontWeight: FontWeight.w400),
+    ),
+  );
+}
+
+_toCheckList() {
+  _rowItem(String text) {
+    return FittedBox(
+      fit: BoxFit.fitWidth,
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.center,
+        mainAxisAlignment: MainAxisAlignment.start,
+        children: [
+          Icon(
+            Icons.brightness_1,
+            size: 10,
+          ),
+          SizedBox(
+            width: 5,
+          ),
+          _subHeading(text),
+        ],
+      ),
+    );
+  }
+
+  return Padding(
+    padding: const EdgeInsets.all(8.0),
+    child: Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        _rowItem("Your backend server is running correctly."),
+        _rowItem("Your base url points to the backend server.")
+      ],
+    ),
+  );
+}
+
+_errorPage() {
+  return Stack(
+    children: [
+      Center(
+        child: Container(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Icon(
+                Icons.error_outline,
+                color: theme.colorScheme.error,
+                size: 100,
+              ),
+              _heading("Well this doesn't seem right?"),
+              _subHeading(
+                  "Something went wrong getting data from the backend."),
+              _subHeading("Please check the following:"),
+              _toCheckList()
+            ],
+          ),
+        ),
+      ),
+    ],
+  );
+}
 
 class _BasePageViewState extends State<BasePageView>
     with SingleTickerProviderStateMixin {
@@ -65,9 +150,11 @@ class _BasePageViewState extends State<BasePageView>
                   } else {
                     model.updateCurrentPage(0);
                     _animationController.animateTo(0);
-                    pageCont.animateToPage(0,
-                        duration: Duration(milliseconds: 400),
-                        curve: Curves.easeInCubic);
+                    pageCont.animateToPage(
+                      0,
+                      duration: Duration(milliseconds: 400),
+                      curve: Curves.easeInCubic,
+                    );
                   }
                 },
               ),
@@ -96,11 +183,13 @@ class _BasePageViewState extends State<BasePageView>
                     physics: NeverScrollableScrollPhysics(),
                     controller: pageCont,
                     children: <Widget>[
-                      HomeView(
-                        apps: model.apps,
-                        tags: model.tags,
-                        viewType: model.viewType,
-                      ),
+                      model.inError
+                          ? _errorPage()
+                          : HomeView(
+                              apps: model.apps,
+                              tags: model.tags,
+                              viewType: model.viewType,
+                            ),
                       SettingsView(),
                     ],
                   ),

--- a/frontend/lib/views/base_page_view.dart
+++ b/frontend/lib/views/base_page_view.dart
@@ -190,7 +190,9 @@ class _BasePageViewState extends State<BasePageView>
                               tags: model.tags,
                               viewType: model.viewType,
                             ),
-                      SettingsView(),
+                      SettingsView(
+                        inError: model.inError,
+                      ),
                     ],
                   ),
                 )

--- a/frontend/lib/views/settings_view.dart
+++ b/frontend/lib/views/settings_view.dart
@@ -63,8 +63,8 @@ funcButton(String text, [Function func]) {
 final urlCont = TextEditingController();
 
 class SettingsView extends StatefulWidget {
-  final Dashboard background;
-  SettingsView({Key key, this.background}) : super(key: key);
+  final bool inError;
+  SettingsView({Key key, this.inError}) : super(key: key);
   @override
   _SettingsViewState createState() => _SettingsViewState();
 }
@@ -225,9 +225,9 @@ class _SettingsViewState extends State<SettingsView> {
                             ],
                           ),
                         ),
-                      AuthService.instance.currentUser != null
-                          ? Container()
-                          : Padding(
+                      AuthService.instance.currentUser == null &&
+                              !widget.inError
+                          ? Padding(
                               padding: const EdgeInsets.all(8),
                               child: Row(
                                 mainAxisAlignment: MainAxisAlignment.center,
@@ -271,7 +271,8 @@ class _SettingsViewState extends State<SettingsView> {
                                   )
                                 ],
                               ),
-                            ),
+                            )
+                          : Container(),
                     ],
                   ),
                 ),

--- a/frontend/lib/views/settings_view.dart
+++ b/frontend/lib/views/settings_view.dart
@@ -133,33 +133,40 @@ class _SettingsViewState extends State<SettingsView> {
                           children: [
                             subHeading("API Url"),
                             Spacer(),
-                            Container(
-                              child: InkWell(
-                                child: Padding(
-                                  child:
-                                      subHeading(APIService.instance.baseUrl),
-                                  padding: EdgeInsets.all(10),
-                                ),
-                                onTap: () {
-                                  showDialog(
-                                    context: context,
-                                    builder: (context) {
-                                      return TextEntryPopUp(
-                                        controller: urlCont,
-                                        function: () async {
-                                          if (urlCont.text != "") {
+                            Row(
+                              children: [
+                                InkWell(
+                                  borderRadius: BorderRadius.circular(100),
+                                  child: Padding(
+                                    child: Icon(
+                                      Icons.edit,
+                                      color: Colors.grey.shade800,
+                                    ),
+                                    padding: EdgeInsets.all(10),
+                                  ),
+                                  onTap: () {
+                                    showDialog(
+                                      context: context,
+                                      builder: (context) {
+                                        return TextEntryPopUp(
+                                          controller: urlCont,
+                                          function: () async {
                                             await model
                                                 .setBaseUrl(urlCont.text);
                                             Navigator.of(context).pop();
-                                          }
-                                        },
-                                        key: Key("Base URL"),
-                                        title: "Update Base URL",
-                                      );
-                                    },
-                                  );
-                                },
-                              ),
+                                          },
+                                          key: Key("Base URL"),
+                                          title: "Update Base URL",
+                                        );
+                                      },
+                                    );
+                                  },
+                                ),
+                                SizedBox(
+                                  width: 10,
+                                ),
+                                subHeading(APIService.instance.baseUrl),
+                              ],
                             )
                           ],
                         ),


### PR DESCRIPTION
Closes #21
Highlights in today's PR include:
* changing the login check to every 5 seconds.
* changing the login check to hit the dashboard URL.
* adding a prerun check that hits the dashboard URL and sets an error state if it does not return as we expect.
* adding in an error page to be shown when in that error state.
* adding a baseUrl stream so when the baseUrl is updated we rerun the checks.
* change baseUrl edit to be a pen instead of the text